### PR TITLE
Install Yum Packages Into the Chroot After it is Setup

### DIFF
--- a/chroot_setup.sh
+++ b/chroot_setup.sh
@@ -296,7 +296,6 @@ function yumInstall {
       fi
     }
 
-    exit 0
   fi
 }
 
@@ -401,9 +400,6 @@ if [ $? -ne 0 ]; then
 fi
 
 CHROOT_DIR=$TEMP_DIR
-
-#perform installs if set then exit
-yumInstall $CHROOT_DIR
 
 # Check if the specified Dir Already Exists
 if [ ! -d "$CHROOT_DIR" ]; then
@@ -522,6 +518,9 @@ for chroot in ${mylist[@]}
   #Clean Up 
   rm $CHROOT_TMP
 }
+# perform installs if set
+yumInstall $CHROOT_DIR
+
 printf "\nTo enter Your Chroot"
 printf "\nRUN: chroot $CHROOT_DIR /QOpenSys/usr/bin/sh\n"
 printf "\n\nDONE!\n"


### PR DESCRIPTION
Now yum install to occurs after the chroot is setup.
This resolves issue #55.

If users would like to add additional software into the chroot after the fact with:
`yum --installroot=/QOpenSys/root_path install package`